### PR TITLE
Fix compiling on Windows

### DIFF
--- a/src/game/server/gamemodes/fb.cpp
+++ b/src/game/server/gamemodes/fb.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <string.h>
 #include <engine/shared/config.h>
 #include <engine/server.h>

--- a/src/game/server/maprotation.cpp
+++ b/src/game/server/maprotation.cpp
@@ -6,7 +6,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <string.h>
 #include <errno.h>
 


### PR DESCRIPTION
- `unistd.h` is not available on Windows. I could delete it without affecting the rest of the code. Is it really necessary on Linux? If it is, consider guarding it with a `#if defined(CONF_FAMILY_UNIX)`

- call to `abs` is ambiguous (it implicitly convers to `int`, ouch). I included `<cmath>` to fix that